### PR TITLE
Tidy to API Skeletons coding standard; more copyright to license for …

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+Copyright (c) 2018, internalsystemerror [need your real name here]
 Copyright (c) 2016, API Skeletons
 Copyright (c) 2013, Martin Shwalbe
 All rights reserved.

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture;
 
@@ -16,7 +16,7 @@ class ConfigProvider
         return [
             'dependencies' => $this->getDependencies(),
             'controllers'  => $this->getControllerDependencyConfig(),
-            'console'      => [
+            'console' => [
                 'router' => $this->getConsoleRouterConfig(),
             ],
         ];

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture\Controller;
 

--- a/src/Controller/HelpControllerFactory.php
+++ b/src/Controller/HelpControllerFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture\Controller;
 

--- a/src/Controller/ImportController.php
+++ b/src/Controller/ImportController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture\Controller;
 
@@ -9,6 +9,7 @@ use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Zend\Mvc\Console\Controller\AbstractConsoleController;
 use ZF\Doctrine\DataFixture\DataFixtureManager;
 use ZF\Doctrine\DataFixture\Loader;
+use RuntimeException;
 
 class ImportController extends AbstractConsoleController
 {
@@ -35,11 +36,11 @@ class ImportController extends AbstractConsoleController
     public function importAction(): void
     {
         if ($this->params()->fromRoute('append')) {
-            throw new \RuntimeException('--append is now the default action');
+            throw new RuntimeException('--append is now the default action');
         }
 
         $loader = new Loader($this->dataFixtureManager);
-        $purger = new ORMPurger;
+        $purger = new ORMPurger();
 
         foreach ($this->dataFixtureManager->getAll() as $fixture) {
             $loader->addFixture($fixture);
@@ -55,7 +56,7 @@ class ImportController extends AbstractConsoleController
         );
         $executor->execute(
             $loader->getFixtures(),
-            (bool)!$this->params()->fromRoute('do-not-append')
+            (bool) ! $this->params()->fromRoute('do-not-append')
         );
     }
 }

--- a/src/Controller/ImportControllerFactory.php
+++ b/src/Controller/ImportControllerFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture\Controller;
 

--- a/src/Controller/ListController.php
+++ b/src/Controller/ListController.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture\Controller;
 
@@ -11,7 +11,6 @@ use ZF\Doctrine\DataFixture\DataFixtureManager;
 
 class ListController extends AbstractConsoleController
 {
-
     /**
      * @var array
      */
@@ -45,29 +44,30 @@ class ListController extends AbstractConsoleController
     public function listAction(): void
     {
         if (!$this->dataFixtureManager) {
-            $this->getConsole()->write("All Fixture Groups\n", Color::RED);
+            $this->getConsole()->writeLine("All Fixture Groups", Color::RED);
 
             foreach ($this->config as $group => $smConfig) {
-                $this->getConsole()->write("$group\n", Color::CYAN);
+                $this->getConsole()->writeLine("$group", Color::CYAN);
             }
 
             return;
         }
 
         $this->getConsole()->write('Group: ', Color::YELLOW);
-        $this->getConsole()->write(
+        $this->getConsole()->writeLine(
             $this->params()
-                 ->fromRoute('fixture-group') . "\n",
+                 ->fromRoute('fixture-group'),
             Color::GREEN
         );
         $this->getConsole()->write('Object Manager: ', Color::YELLOW);
-        $this->getConsole()
-             ->write($this->dataFixtureManager->getObjectManagerAlias()
-                     . "\n", Color::GREEN);
+        $this->getConsole()->writeLine(
+             $this->dataFixtureManager->getObjectManagerAlias(),
+             Color::GREEN
+         );
 
         foreach ($this->dataFixtureManager->getAll() as $fixture) {
-            $this->getConsole()->write(
-                get_class($fixture) . "\n",
+            $this->getConsole()->writeLine(
+                get_class($fixture),
                 Color::CYAN
             );
         }

--- a/src/Controller/ListControllerFactory.php
+++ b/src/Controller/ListControllerFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture\Controller;
 
@@ -27,8 +27,7 @@ class ListControllerFactory implements FactoryInterface
 
         // If an object manager and group are specified include the data fixture manager
         if ($request->params()->get(1)) {
-            $dataFixtureManager
-                = $container->get(DataFixtureManager::class);
+            $dataFixtureManager = $container->get(DataFixtureManager::class);
         }
 
         $instance = new ListController(

--- a/src/DataFixtureManager.php
+++ b/src/DataFixtureManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture;
 
@@ -56,9 +56,11 @@ class DataFixtureManager extends ServiceManager implements ObjectManagerAwareInt
      *
      * @return void
      */
-    public function setObjectManagerAlias(string $alias): void
+    public function setObjectManagerAlias(string $alias): DataFixtureManager
     {
         $this->objectManagerAlias = $alias;
+
+        return $this;
     }
 
     /**
@@ -78,8 +80,10 @@ class DataFixtureManager extends ServiceManager implements ObjectManagerAwareInt
      *
      * @return void
      */
-    public function setServiceLocator(ContainerInterface $serviceLocator): void
+    public function setServiceLocator(ContainerInterface $serviceLocator): DataFixtureManager
     {
         $this->serviceLocator = $serviceLocator;
+
+        return $this;
     }
 }

--- a/src/DataFixtureManagerFactory.php
+++ b/src/DataFixtureManagerFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture;
 
@@ -11,7 +11,6 @@ use Zend\ServiceManager\Factory\FactoryInterface;
 
 class DataFixtureManagerFactory implements FactoryInterface
 {
-
     /**
      * @inheritdoc
      */
@@ -41,7 +40,7 @@ class DataFixtureManagerFactory implements FactoryInterface
 
         // Load instance
         $objectManagerAlias
-                  = (string)$config['doctrine']['fixture'][$fixtureGroup]['object_manager'];
+            = (string)$config['doctrine']['fixture'][$fixtureGroup]['object_manager'];
         $instance = new DataFixtureManager(
             (array)$config['doctrine']['fixture'][$fixtureGroup]
         );

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -1,8 +1,6 @@
 <?php
-/**
- * @copyright 2018 Internalsystemerror Limited
- */
-declare(strict_types=1);
+
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture;
 
@@ -11,7 +9,6 @@ use Doctrine\Common\DataFixtures\Loader as DoctrineLoader;
 
 class Loader extends DoctrineLoader
 {
-
     /**
      * @var DataFixtureManager
      */

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace ZF\Doctrine\DataFixture;
 
@@ -15,7 +15,6 @@ class Module implements
     AutoloaderProviderInterface,
     ConsoleUsageProviderInterface
 {
-
     /**
      * @inheritdoc
      */
@@ -23,11 +22,11 @@ class Module implements
     {
         return [
             'data-fixture:help'
-            => 'Data Fixtures Help',
+                => 'Data Fixtures Help',
             'data-fixture:list [<group>]'
-            => 'List Data Fixtures',
+                => 'List Data Fixtures',
             'data-fixture:import <group> [--append] [--purge-with-truncate]'
-            => 'Import Data Fixtures',
+                => 'Import Data Fixtures',
         ];
     }
 
@@ -36,12 +35,12 @@ class Module implements
      */
     public function getConfig(): array
     {
-        $configProvider = new ConfigProvider;
+        $configProvider = new ConfigProvider();
 
         return [
             'service_manager' => $configProvider->getDependencies(),
-            'controllers'     => $configProvider->getControllerDependencyConfig(),
-            'console'         => [
+            'controllers' => $configProvider->getControllerDependencyConfig(),
+            'console' => [
                 'router' => $configProvider->getConsoleRouterConfig(),
             ],
         ];


### PR DESCRIPTION
Updated to my phpcs config; () after classes, => not alligned, space pad all operators; right pad ! operator.

Moved your copyright to the license instead of having individual copyright on files.  It is either this or I implement a policy that contributed code belongs to API Skeletons and then license under MIT from that name.

API Skeletons does need a more official phpcs config.  